### PR TITLE
Fix elapsed time calculation and enhance responsive design

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,11 +14,12 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  min-height: 100vh;
+  padding: 20px;
 }
 
 .title {
-  font-size: 4rem;
+  font-size: clamp(2rem, 8vw, 4rem);
   margin-bottom: 30px;
   color: #ffffff;
   text-shadow: 3px 3px #ff69b4;

--- a/src/components/Counter.css
+++ b/src/components/Counter.css
@@ -18,7 +18,8 @@
   box-shadow: 0 0 30px rgba(255, 255, 255, 0.2);
   backdrop-filter: blur(10px);
   transition: transform 0.3s;
-  max-width: 90vw; /* Ensure the counter doesn't overflow on very small screens */
+  width: 100%;
+  max-width: 600px;
 }
 
 .counter:hover {
@@ -46,7 +47,7 @@
 }
 
 .number {
-  font-size: 2.5rem;
+  font-size: clamp(1.8rem, 5vw, 2.5rem);
   font-weight: bold;
   display: block;
   margin-bottom: 5px;
@@ -63,7 +64,7 @@
 }
 
 .label {
-  font-size: 1rem;
+  font-size: clamp(0.8rem, 2vw, 1rem);
   color: #ffffff;
   font-family: 'Montserrat', sans-serif;
 }
@@ -82,19 +83,6 @@
     padding: 20px 25px;
   }
 
-  .title {
-    font-size: 3rem; /* Adjust title size for smaller screens */
-  }
-
-  .number {
-    font-size: 2rem;
-    min-width: 40px;
-  }
-
-  .label {
-    font-size: 0.9rem;
-  }
-
   .time-section {
     gap: 15px;
   }
@@ -103,15 +91,6 @@
 @media (max-width: 480px) {
   .counter {
     padding: 15px 20px;
-  }
-
-  .number {
-    font-size: 1.8rem;
-    min-width: 35px;
-  }
-
-  .label {
-    font-size: 0.8rem;
   }
 
   .time-section {

--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './Counter.css';
+import { calculateElapsedTime } from '../utils/time';
 
 const Counter = () => {
   const startDate = new Date(process.env.REACT_APP_START_DATE).getTime();
@@ -17,29 +18,7 @@ const Counter = () => {
     return number < 10 ? `0${number}` : number;
   };
 
-  const calculateElapsed = () => {
-    let elapsed = currentTime - startDate;
-
-    if (elapsed < 0) {
-      return null;
-    }
-
-    const milliseconds = elapsed % 1000;
-    const totalSeconds = Math.floor(elapsed / 1000);
-    const seconds = totalSeconds % 60;
-    const totalMinutes = Math.floor(totalSeconds / 60);
-    const minutes = totalMinutes % 60;
-    const totalHours = Math.floor(totalMinutes / 60);
-    const hours = totalHours % 24;
-    const totalDays = Math.floor(totalHours / 24);
-    const days = totalDays % 365;
-    const years = Math.floor(totalDays / 365);
-    const months = Math.floor((totalDays % 365) / 30); // Approximation
-
-    return { years, months, days, hours, minutes, seconds, milliseconds };
-  };
-
-  const elapsed = calculateElapsed();
+  const elapsed = calculateElapsedTime(startDate, currentTime);
 
   // If the start date is in the future
   if (!elapsed) {

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,44 @@
+export function calculateElapsedTime(startTime, endTime) {
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+
+  if (end < start) {
+    return null;
+  }
+
+  let years = end.getFullYear() - start.getFullYear();
+  let months = end.getMonth() - start.getMonth();
+  let days = end.getDate() - start.getDate();
+  let hours = end.getHours() - start.getHours();
+  let minutes = end.getMinutes() - start.getMinutes();
+  let seconds = end.getSeconds() - start.getSeconds();
+  let milliseconds = end.getMilliseconds() - start.getMilliseconds();
+
+  if (milliseconds < 0) {
+    milliseconds += 1000;
+    seconds -= 1;
+  }
+  if (seconds < 0) {
+    seconds += 60;
+    minutes -= 1;
+  }
+  if (minutes < 0) {
+    minutes += 60;
+    hours -= 1;
+  }
+  if (hours < 0) {
+    hours += 24;
+    days -= 1;
+  }
+  if (days < 0) {
+    const previousMonth = new Date(end.getFullYear(), end.getMonth(), 0);
+    days += previousMonth.getDate();
+    months -= 1;
+  }
+  if (months < 0) {
+    months += 12;
+    years -= 1;
+  }
+
+  return { years, months, days, hours, minutes, seconds, milliseconds };
+}

--- a/src/utils/time.test.js
+++ b/src/utils/time.test.js
@@ -1,0 +1,39 @@
+import { calculateElapsedTime } from './time';
+
+describe('calculateElapsedTime', () => {
+  it('calculates one day difference', () => {
+    const start = new Date('2020-01-01T00:00:00Z').getTime();
+    const end = new Date('2020-01-02T00:00:00Z').getTime();
+    const result = calculateElapsedTime(start, end);
+    expect(result).toMatchObject({ years: 0, months: 0, days: 1 });
+  });
+
+  it('calculates one month difference', () => {
+    const start = new Date('2020-01-01T00:00:00Z').getTime();
+    const end = new Date('2020-02-01T00:00:00Z').getTime();
+    const result = calculateElapsedTime(start, end);
+    expect(result).toMatchObject({ years: 0, months: 1, days: 0 });
+  });
+
+  it('calculates one year difference', () => {
+    const start = new Date('2020-01-01T00:00:00Z').getTime();
+    const end = new Date('2021-01-01T00:00:00Z').getTime();
+    const result = calculateElapsedTime(start, end);
+    expect(result).toMatchObject({ years: 1, months: 0, days: 0 });
+  });
+
+  it('calculates a complex difference accurately', () => {
+    const start = new Date('2020-01-01T01:02:03.004Z').getTime();
+    const end = new Date('2021-02-03T04:05:06.007Z').getTime();
+    const result = calculateElapsedTime(start, end);
+    expect(result).toEqual({
+      years: 1,
+      months: 1,
+      days: 2,
+      hours: 3,
+      minutes: 3,
+      seconds: 3,
+      milliseconds: 3,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace rough time math with `calculateElapsedTime` utility
- add unit tests for day, month and year differences
- improve layout responsiveness with fluid typography and widths

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6897177f3c9c832c9758588854c498de